### PR TITLE
Bump up the version of rxdart to 0.18.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
 dependencies:
-  rxdart: ">=0.16.5 <0.17.0"
+  rxdart: ">=0.16.5 <0.18.0"
   redux: ">=3.0.0 <4.0.0"
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
 dependencies:
-  rxdart: ">=0.16.5 <0.18.0"
+  rxdart: ">=0.18.0 <0.19.0"
   redux: ">=3.0.0 <4.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
As mentioned in the [thread](https://github.com/ReactiveX/rxdart/issues/160) the deprecated `retype` has been removed from Dart 2.
As the dart_redux_epics do rely on the `rxdart` <= 0.17.0 the error mentioned in the [topic](https://github.com/ReactiveX/rxdart/issues/160) started appearing.