### PR TITLE
Update pubspec to allow rxdart 0.20.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   redux: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
-  test: ">=0.12.33 <0.13.0"
+  test: ">=0.12.33 <=1.5.1"


### PR DESCRIPTION
`dart_redux_epics` currently specifies a max version of rxDart of 0.18.0.

rxDart 0.20.0 brings a bunch of useful changes regarding `combineLatest`. There are a couple of breaking changes according to the rxDart changelog, but they don't appear to affect this project:

https://github.com/ReactiveX/rxdart/releases

Also allowed the latest version of `test` to keep up with changes to Dart and get the Travis build to pass.