### PR TITLE
Compatibility with Dart 2.0.0

### DIFF
--- a/lib/src/epic_store.dart
+++ b/lib/src/epic_store.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:redux/redux.dart';
 import 'package:redux_epics/src/epic.dart';
 


### PR DESCRIPTION
In Dart 2.1 dart:core exports Future and Stream but in 2.0 it doesn't so the build fails. This import will solve the issue and won't affect Dart 2.1