### PR TITLE
Combined epic should be called once during initialization

### DIFF
--- a/lib/src/combine_epics.dart
+++ b/lib/src/combine_epics.dart
@@ -24,6 +24,7 @@ import 'package:rxdart/streams.dart';
 ///     ]);
 Epic<State> combineEpics<State>(List<Epic<State>> epics) {
   return (Stream<dynamic> actions, EpicStore<State> store) {
-    return new MergeStream<dynamic>(epics.map((epic) => epic(actions, store)));
+    return new MergeStream<dynamic>(
+        epics.map((epic) => epic(actions, store)).toList());
   };
 }

--- a/test/epic_middleware_test.dart
+++ b/test/epic_middleware_test.dart
@@ -243,5 +243,25 @@ void main() {
         ]),
       );
     });
+
+    test('combined epic called once during initialization', () {
+      int epicCalledTimes = 0;
+      Stream<dynamic> epicWithCallCount(
+        Stream<dynamic> actions,
+        EpicStore<String> store,
+      ) {
+        epicCalledTimes++;
+        return Stream<dynamic>.empty();
+      }
+
+      final store = new Store<String>(
+        latestActionReducer,
+        middleware: [
+          new EpicMiddleware<String>(combineEpics<String>([epicWithCallCount]))
+        ],
+      );
+      store.dispatch(new Request1());
+      expect(epicCalledTimes, 1);
+    });
   });
 }


### PR DESCRIPTION
Hi @brianegan, thanks for your work on this package!

We noticed that combined epic function called multiple times during initialization which seems to be a bad thing due to performance & might cause some issues if a user doesn't expect it to be called multiple times. 

Could you please review this PR and let us know what you think?