### PR TITLE
Fix example in documentation of EpicClass

### DIFF
--- a/lib/src/epic.dart
+++ b/lib/src/epic.dart
@@ -62,7 +62,7 @@ typedef Stream<dynamic> Epic<State>(
 ///
 ///     class ExampleEpic extends EpicClass<State> {
 ///       @override
-///       Stream<dynamic> map(Stream<dynamic> actions, EpicStore<State> store) {
+///       Stream<dynamic> call(Stream<dynamic> actions, EpicStore<State> store) {
 ///         return actions
 ///           .where((action) => action is PerformSearchAction)
 ///           .asyncMap((action) =>


### PR DESCRIPTION
Minor fix to the example in EpicClass's documentation. Example references `EpicClass.map`, but this has since been renamed to `call`.