### PR TITLE
Allow rxdart 0.27.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  rxdart: ">=0.26.0 <0.27.0"
+  rxdart: ">=0.26.0 <0.28.0"
   redux: ">=5.0.0 <6.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
The [breaking change](https://pub.dev/packages/rxdart/changelog#0270) in rxdart 0.27 does not affect this package.

Closes #45